### PR TITLE
Add --skip-permissions flag for Sail container sandboxed execution

### DIFF
--- a/scripts/ralph-loop.cjs
+++ b/scripts/ralph-loop.cjs
@@ -41,6 +41,7 @@ function parseArgs() {
     sessionId: null,
     budget: null,
     fresh: false,
+    skipPermissions: false,
     logPath: null,
     maxConsecutiveFailures: parseInt(
       process.env.AGENT_MAX_CONSECUTIVE_FAILURES || "3",
@@ -77,6 +78,9 @@ function parseArgs() {
         break;
       case "--fresh":
         parsed.fresh = true;
+        break;
+      case "--skip-permissions":
+        parsed.skipPermissions = true;
         break;
       case "--log-path":
         parsed.logPath = args[++i];
@@ -314,9 +318,13 @@ function buildClaudeArgs(config, prompt, iteration) {
     "--verbose",
     "--output-format",
     "stream-json",
-    "--permission-mode",
-    config.permissionMode,
   ];
+
+  if (config.skipPermissions) {
+    commonArgs.push("--dangerously-skip-permissions");
+  } else {
+    commonArgs.push("--permission-mode", config.permissionMode);
+  }
 
   if (config.model) {
     commonArgs.push("--model", config.model);
@@ -384,6 +392,9 @@ async function main() {
     `${color.bold}${color.blue}║  Resume: ${resumeMode ? "enabled" : "disabled"}${color.reset}`,
   );
   console.log(
+    `${color.bold}${color.blue}║  Skip permissions: ${config.skipPermissions ? "yes" : "no"}${color.reset}`,
+  );
+  console.log(
     `${color.bold}${color.blue}║  Log: ${logger.path}${color.reset}`,
   );
   console.log(
@@ -394,6 +405,7 @@ async function main() {
   logger.info(`Starting ralph loop: ${config.name}`);
   logger.info(`Iterations: ${config.iterations}`);
   logger.info(`Permission mode: ${config.permissionMode}`);
+  logger.info(`Skip permissions: ${config.skipPermissions}`);
   logger.info(`Model: ${config.model || "default"}`);
   logger.info(`Session ID: ${config.sessionId || "none"}`);
   logger.info(`Resume: ${resumeMode ? "enabled" : "disabled"}`);
@@ -447,7 +459,12 @@ async function main() {
           );
           logger.info("Retrying iteration as fresh invocation");
 
-          const freshArgs = ["-p", fullPrompt, "--verbose", "--output-format", "stream-json", "--permission-mode", config.permissionMode];
+          const freshArgs = ["-p", fullPrompt, "--verbose", "--output-format", "stream-json"];
+          if (config.skipPermissions) {
+            freshArgs.push("--dangerously-skip-permissions");
+          } else {
+            freshArgs.push("--permission-mode", config.permissionMode);
+          }
           if (config.model) freshArgs.push("--model", config.model);
           if (config.budget) freshArgs.push("--max-budget-usd", config.budget);
 

--- a/scripts/ralph-loop.cjs
+++ b/scripts/ralph-loop.cjs
@@ -80,6 +80,12 @@ function parseArgs() {
         parsed.fresh = true;
         break;
       case "--skip-permissions":
+        if (process.env.LARAVEL_SAIL !== "1") {
+          console.error(
+            `${color.red}Error: --skip-permissions requires LARAVEL_SAIL=1 (Sail container).${color.reset}`,
+          );
+          process.exit(1);
+        }
         parsed.skipPermissions = true;
         break;
       case "--log-path":
@@ -404,8 +410,7 @@ async function main() {
 
   logger.info(`Starting ralph loop: ${config.name}`);
   logger.info(`Iterations: ${config.iterations}`);
-  logger.info(`Permission mode: ${config.permissionMode}`);
-  logger.info(`Skip permissions: ${config.skipPermissions}`);
+  logger.info(`Permissions: ${config.skipPermissions ? "skipped (dangerously)" : `mode=${config.permissionMode}`}`);
   logger.info(`Model: ${config.model || "default"}`);
   logger.info(`Session ID: ${config.sessionId || "none"}`);
   logger.info(`Resume: ${resumeMode ? "enabled" : "disabled"}`);

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -28,7 +28,8 @@ class StartCommand extends Command
         {--fresh : Each iteration starts a fresh Claude session}
         {--resume : Resume a previously stopped session}
         {--attach : Attach to screen session after starting}
-        {--once : Run single iteration in foreground}';
+        {--once : Run single iteration in foreground}
+        {--skip-permissions : Run Claude with --dangerously-skip-permissions (requires Sail container)}';
 
     protected $description = 'Start a Ralph agent loop';
 
@@ -36,6 +37,12 @@ class StartCommand extends Command
     {
         if ($this->option('fresh') && $this->option('resume')) {
             $this->components->error('--fresh and --resume are mutually exclusive.');
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('skip-permissions') && ! getenv('LARAVEL_SAIL')) {
+            $this->components->error('The --skip-permissions flag requires a Sail container (LARAVEL_SAIL=1)');
 
             return self::FAILURE;
         }
@@ -72,6 +79,7 @@ class StartCommand extends Command
         $logger->info("Iterations: {$iterations}");
         $logger->info('Model: '.($model ?? 'default'));
         $logger->info('Mode: '.($this->option('fresh') ? 'fresh' : 'resume'));
+        $logger->info('Skip permissions: '.($this->option('skip-permissions') ? 'true' : 'false'));
         $logger->info("Working dir: {$workingDir}");
 
         // Build the ralph-loop command
@@ -482,6 +490,10 @@ class StartCommand extends Command
 
         if ($this->option('fresh')) {
             $cmd .= ' --fresh';
+        }
+
+        if ($this->option('skip-permissions')) {
+            $cmd .= ' --skip-permissions';
         }
 
         return $cmd;

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -464,19 +464,23 @@ class StartCommand extends Command
 
     private function buildLoopCommand(string $scriptPath, string $prompt, string $name, int $iterations, string $sessionId, string $logPath): string
     {
-        /** @var string $permissionMode */
-        $permissionMode = config('ralph.loop.permission_mode');
-
         $cmd = sprintf(
-            'node %s --prompt %s --name %s --iterations %d --permission-mode %s --session-id %s --log-path %s',
+            'node %s --prompt %s --name %s --iterations %d --session-id %s --log-path %s',
             escapeshellarg($scriptPath),
             escapeshellarg($prompt),
             escapeshellarg($name),
             $iterations,
-            escapeshellarg($permissionMode),
             escapeshellarg($sessionId),
             escapeshellarg($logPath),
         );
+
+        if ($this->option('skip-permissions')) {
+            $cmd .= ' --skip-permissions';
+        } else {
+            /** @var string $permissionMode */
+            $permissionMode = config('ralph.loop.permission_mode');
+            $cmd .= ' --permission-mode '.escapeshellarg($permissionMode);
+        }
 
         $model = $this->resolveModel();
         if (is_string($model)) {
@@ -490,10 +494,6 @@ class StartCommand extends Command
 
         if ($this->option('fresh')) {
             $cmd .= ' --fresh';
-        }
-
-        if ($this->option('skip-permissions')) {
-            $cmd .= ' --skip-permissions';
         }
 
         return $cmd;

--- a/tests/Feature/RalphCommandsTest.php
+++ b/tests/Feature/RalphCommandsTest.php
@@ -105,6 +105,26 @@ test('ralph:init merges with existing settings', function () {
     File::deleteDirectory($claudeDir);
 });
 
+test('ralph:start --skip-permissions fails without LARAVEL_SAIL', function () {
+    // Ensure LARAVEL_SAIL is not set
+    putenv('LARAVEL_SAIL');
+    unset($_ENV['LARAVEL_SAIL'], $_SERVER['LARAVEL_SAIL']);
+
+    $this->artisan('ralph:start --skip-permissions --once --prompt "test" test-session')
+        ->expectsOutputToContain('--skip-permissions flag requires a Sail container')
+        ->assertExitCode(1);
+});
+
+test('ralph:start --skip-permissions guard checks LARAVEL_SAIL env', function () {
+    // Verify the guard logic directly: with LARAVEL_SAIL=1, getenv() returns truthy
+    putenv('LARAVEL_SAIL=1');
+    expect(getenv('LARAVEL_SAIL'))->toBeTruthy();
+
+    // Without LARAVEL_SAIL, getenv() returns false (falsy)
+    putenv('LARAVEL_SAIL');
+    expect(getenv('LARAVEL_SAIL'))->toBeFalsy();
+});
+
 test('ralph:init fails on invalid existing json', function () {
     $claudeDir = base_path('.claude');
     $settingsPath = $claudeDir.'/settings.json';


### PR DESCRIPTION
## Summary
- Add `--skip-permissions` flag to `ralph:start` that uses `--dangerously-skip-permissions` instead of `--permission-mode` when invoking Claude
- Safety guard: flag requires `LARAVEL_SAIL=1` env var, preventing accidental use on bare metal
- Both `buildClaudeArgs()` and resume-failed-retry fallback paths handle the flag
- Logging in both PHP and JS startup output

Closes #1

## Test plan
- [x] `ralph:start --skip-permissions` outside container fails with error
- [x] `LARAVEL_SAIL=1` env check validates correctly
- [x] All 21 existing tests pass
- [x] `pint` clean
- [x] `phpstan` clean